### PR TITLE
feat: add destroy() method to Cache for proper cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Each entry in cache can has its own TTL (timeout) and assigned expiration callba
     -   [has](#has)
     -   [delete](#delete)
     -   [flush](#flush)
+    -   [destroy](#destroy)
 
 ## Installation
 
@@ -42,11 +43,11 @@ const cache = new Cache<number, string>();
 
 Cache behavior can be altered with `options` object passed to its constructor. Following table shows options that can be changed.
 
-| Option     | Default value | Description                                                         |
-| ---------- | ------------- | ------------------------------------------------------------------- |
-| ~~resolution~~ | ~~1000~~ | **Deprecated.** Previously set interval for checking expiry. Now items expire at exact TTL times using dynamic timeout scheduling for improved accuracy. |
-| defaultTTL | Infinity      | Default TTL for all added entries                                   |
-| maxItems   | 1000          | Maximum number of entries stored in cache                           |
+| Option         | Default value | Description                                                                                                                                              |
+| -------------- | ------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ~~resolution~~ | ~~1000~~      | **Deprecated.** Previously set interval for checking expiry. Now items expire at exact TTL times using dynamic timeout scheduling for improved accuracy. |
+| defaultTTL     | Infinity      | Default TTL for all added entries                                                                                                                        |
+| maxItems       | 1000          | Maximum number of entries stored in cache                                                                                                                |
 
 **Expiration Accuracy**: Cache entries now expire at their exact TTL expiration time rather than being checked periodically. This provides better accuracy and performance by scheduling cleanup events precisely when items expire, instead of checking all items at fixed intervals.
 
@@ -286,4 +287,64 @@ cache.flush(true);
 
 // Flush cache without invoking callbacks
 cache.flush();
+```
+
+### destroy
+
+Destroys the cache instance, clearing all entries and stopping the internal cleanup timer. Use this in test teardown (`afterEach`) or when a cache instance is no longer needed to prevent resource leaks.
+
+Prototype:
+
+```ts
+public destroy(invokeCallbacks: boolean = false) : void
+```
+
+Params:
+
+-   `invokeCallbacks (default: false)`: If set to `true`, any expiration callback assigned to an entry will be called before the entry is deleted.
+
+After `destroy()` is called, all methods throw an error (`Cache instance has been destroyed`) except:
+
+-   `destroy()` itself — idempotent, safe to call multiple times
+-   `flush()` — safe to call (no-op on empty cache)
+
+Return value:
+
+`destroy` does not return a value.
+
+Example:
+
+```ts
+import { Cache } from '@m4x1m1l14n/cache';
+
+const cache = new Cache<number, string>();
+
+cache.set(1, 'Hello');
+cache.set(2, 'World');
+
+// Destroy and invoke callbacks
+cache.destroy(true);
+
+// Or destroy without invoking callbacks
+const cache2 = new Cache<number, string>();
+cache2.set(1, 'Hello');
+cache2.destroy();
+```
+
+**Jest / testing example:**
+
+```ts
+describe('MyService', () => {
+	let cache: Cache<string, string>;
+
+	beforeEach(() => {
+		cache = new Cache();
+	});
+
+	afterEach(() => {
+		cache.destroy();
+	});
+
+	// ... tests ...
+});
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@m4x1m1l14n/cache",
-	"version": "1.2.0",
+	"version": "1.2.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@m4x1m1l14n/cache",
-			"version": "1.2.0",
+			"version": "1.2.1",
 			"license": "MIT",
 			"dependencies": {
 				"detect-node": "^2.1.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@m4x1m1l14n/cache",
-	"version": "1.2.0",
+	"version": "1.2.1",
 	"description": "Lightweight in-memory isomorphic cache implementation with TTL for browser & Node JS written in TypeScript",
 	"main": "dist/main.js",
 	"types": "dist/main.d.ts",

--- a/src/classes/Cache.ts
+++ b/src/classes/Cache.ts
@@ -14,6 +14,7 @@ export class Cache<K, T> {
 	private cache = new Map<K, CacheValue<T>>();
 	private timeoutHandle: NodeJS.Timeout | number | null = null;
 	private expirationHeap = new MinHeap<K>();
+	private destroyed = false;
 
 	constructor(options?: CacheOptions) {
 		this.options = {
@@ -32,6 +33,10 @@ export class Cache<K, T> {
 	}
 
 	public set(key: K, value: T, ttl?: number, callback?: ExpirationCallback<T>): Cache<K, T> {
+		if (this.destroyed) {
+			throw new Error('Cache instance has been destroyed');
+		}
+
 		const now = getMilliseconds();
 		const itemTTL = ttl ?? this.options.defaultTTL;
 
@@ -51,7 +56,7 @@ export class Cache<K, T> {
 		if (itemTTL !== Number.POSITIVE_INFINITY) {
 			this.expirationHeap.insert({
 				expiration: now + itemTTL,
-				key
+				key,
 			});
 		}
 
@@ -68,6 +73,10 @@ export class Cache<K, T> {
 	 * @param refresh True to refresh item TTL or false to not
 	 */
 	public get(key: K, refresh = false): T | undefined {
+		if (this.destroyed) {
+			throw new Error('Cache instance has been destroyed');
+		}
+
 		const wrapped = this.cache.get(key);
 		if (!wrapped) {
 			return undefined;
@@ -80,11 +89,11 @@ export class Cache<K, T> {
 			// Item is expired, remove it
 			this.cache.delete(key);
 			this.expirationHeap.removeByKey(key);
-			
+
 			if (wrapped.callback) {
 				wrapped.callback(wrapped.value);
 			}
-			
+
 			return undefined;
 		}
 
@@ -93,15 +102,15 @@ export class Cache<K, T> {
 			this.expirationHeap.removeByKey(key);
 
 			wrapped.created = now;
-			
+
 			// Add new expiration entry if item has finite TTL
 			if (wrapped.ttl !== Number.POSITIVE_INFINITY) {
 				this.expirationHeap.insert({
 					expiration: now + wrapped.ttl,
-					key
+					key,
 				});
 			}
-			
+
 			// Reschedule cleanup since we refreshed an item's TTL
 			this.scheduleCleanup();
 		}
@@ -127,6 +136,10 @@ export class Cache<K, T> {
 	}
 
 	public has(key: K): boolean {
+		if (this.destroyed) {
+			throw new Error('Cache instance has been destroyed');
+		}
+
 		const wrapped = this.cache.get(key);
 		if (!wrapped) {
 			return false;
@@ -138,11 +151,11 @@ export class Cache<K, T> {
 			// Item is expired, remove it
 			this.cache.delete(key);
 			this.expirationHeap.removeByKey(key);
-			
+
 			if (wrapped.callback) {
 				wrapped.callback(wrapped.value);
 			}
-			
+
 			return false;
 		}
 
@@ -150,18 +163,26 @@ export class Cache<K, T> {
 	}
 
 	public delete(key: K): boolean {
+		if (this.destroyed) {
+			throw new Error('Cache instance has been destroyed');
+		}
+
 		const result = this.cache.delete(key);
-		
+
 		// Remove from expiration heap and reschedule cleanup since we removed an item
 		if (result) {
 			this.expirationHeap.removeByKey(key);
 			this.scheduleCleanup();
 		}
-		
+
 		return result;
 	}
 
 	public mdelete(keys: K[]): Cache<K, T> {
+		if (this.destroyed) {
+			throw new Error('Cache instance has been destroyed');
+		}
+
 		let deletedAny = false;
 		for (const key of keys) {
 			if (this.cache.delete(key)) {
@@ -179,10 +200,18 @@ export class Cache<K, T> {
 	}
 
 	public get size(): number {
+		if (this.destroyed) {
+			throw new Error('Cache instance has been destroyed');
+		}
+
 		return this.cache.size;
 	}
 
 	public forEach(cb: (value: T, key: K) => void): void {
+		if (this.destroyed) {
+			throw new Error('Cache instance has been destroyed');
+		}
+
 		this.cache.forEach((value, key) => {
 			cb(value.value, key);
 		});
@@ -231,13 +260,13 @@ export class Cache<K, T> {
 		while (!this.expirationHeap.isEmpty) {
 			const peek = this.expirationHeap.peek()!;
 			const cached = this.cache.get(peek.key);
-			
+
 			// If the item doesn't exist in cache or the expiration doesn't match, remove from heap
 			if (!cached || cached.created + cached.ttl !== peek.expiration) {
 				this.expirationHeap.extractMin();
 				continue;
 			}
-			
+
 			// Found a valid entry
 			return peek.expiration;
 		}
@@ -283,6 +312,15 @@ export class Cache<K, T> {
 		}
 	}
 
+	public destroy(invokeCallbacks: boolean = false): void {
+		if (this.destroyed) {
+			return;
+		}
+
+		this.destroyed = true;
+		this.flush(invokeCallbacks);
+	}
+
 	public flush(invokeCallback: boolean = false) {
 		if (invokeCallback) {
 			for (const [, value] of this.cache) {
@@ -294,7 +332,7 @@ export class Cache<K, T> {
 
 		this.cache.clear();
 		this.expirationHeap.clear();
-		
+
 		// Clear any scheduled cleanup since cache is empty
 		this.clearScheduledCleanup();
 	}

--- a/test/Cache.destroy.test.ts
+++ b/test/Cache.destroy.test.ts
@@ -1,0 +1,453 @@
+import { Cache } from '../src/classes/Cache';
+
+describe('Cache.destroy()', () => {
+	beforeEach(() => {
+		jest.useFakeTimers();
+	});
+
+	afterEach(() => {
+		jest.useRealTimers();
+	});
+
+	// --- Lifecycle tests ---
+
+	test('destroy() stops the cleanup timeout', () => {
+		const cache = new Cache<number, string>();
+		const callback = jest.fn();
+
+		cache.set(1, 'value', 100, callback);
+
+		// Timeout should be scheduled
+		expect((cache as any).timeoutHandle).not.toBeNull();
+
+		cache.destroy();
+
+		// Timeout should be cleared
+		expect((cache as any).timeoutHandle).toBeNull();
+
+		// Advance time past the TTL — callback should NOT fire via cleanup
+		jest.advanceTimersByTime(200);
+		// Callback was invoked by flush during destroy, not by the timer
+		expect(callback).not.toHaveBeenCalled();
+	});
+
+	test('destroy(true) invokes expiration callbacks', () => {
+		const cache = new Cache<number, string>();
+		const callback = jest.fn();
+
+		cache.set(1, 'value1', 100, callback);
+		cache.set(2, 'value2', 200, callback);
+
+		cache.destroy(true);
+
+		expect(callback).toHaveBeenCalledTimes(2);
+		expect(callback).toHaveBeenCalledWith('value1');
+		expect(callback).toHaveBeenCalledWith('value2');
+	});
+
+	test('destroy(false) does not invoke expiration callbacks', () => {
+		const cache = new Cache<number, string>();
+		const callback = jest.fn();
+
+		cache.set(1, 'value1', 100, callback);
+		cache.set(2, 'value2', 200, callback);
+
+		cache.destroy(false);
+
+		expect(callback).not.toHaveBeenCalled();
+	});
+
+	test('destroy() without arguments does not invoke callbacks (default)', () => {
+		const cache = new Cache<number, string>();
+		const callback = jest.fn();
+
+		cache.set(1, 'value1', 100, callback);
+
+		cache.destroy();
+
+		expect(callback).not.toHaveBeenCalled();
+	});
+
+	test('destroy() flushes all cached entries', () => {
+		const cache = new Cache<number, string>();
+
+		cache.set(1, 'a');
+		cache.set(2, 'b');
+		cache.set(3, 'c');
+
+		expect((cache as any).cache.size).toBe(3);
+
+		cache.destroy();
+
+		expect((cache as any).cache.size).toBe(0);
+	});
+
+	test('destroy() is idempotent — calling twice does not throw', () => {
+		const cache = new Cache<number, string>();
+
+		cache.set(1, 'value');
+
+		expect(() => {
+			cache.destroy();
+			cache.destroy();
+		}).not.toThrow();
+	});
+
+	test('destroy() is idempotent — callbacks invoked only once', () => {
+		const cache = new Cache<number, string>();
+		const callback = jest.fn();
+
+		cache.set(1, 'value', 100, callback);
+
+		cache.destroy(true);
+		cache.destroy(true);
+
+		expect(callback).toHaveBeenCalledTimes(1);
+	});
+
+	// --- Use after destroy ---
+
+	test('after destroy(), set() throws an error', () => {
+		const cache = new Cache<number, string>();
+
+		cache.destroy();
+
+		expect(() => cache.set(1, 'value')).toThrow('Cache instance has been destroyed');
+	});
+
+	test('after destroy(), get() throws an error', () => {
+		const cache = new Cache<number, string>();
+
+		cache.set(1, 'value');
+		cache.destroy();
+
+		expect(() => cache.get(1)).toThrow('Cache instance has been destroyed');
+	});
+
+	test('after destroy(), has() throws an error', () => {
+		const cache = new Cache<number, string>();
+
+		cache.set(1, 'value');
+		cache.destroy();
+
+		expect(() => cache.has(1)).toThrow('Cache instance has been destroyed');
+	});
+
+	test('after destroy(), size throws an error', () => {
+		const cache = new Cache<number, string>();
+
+		cache.set(1, 'value');
+		cache.destroy();
+
+		expect(() => cache.size).toThrow('Cache instance has been destroyed');
+	});
+
+	test('after destroy(), take() throws an error', () => {
+		const cache = new Cache<number, string>();
+
+		cache.set(1, 'value');
+		cache.destroy();
+
+		expect(() => cache.take(1)).toThrow('Cache instance has been destroyed');
+	});
+
+	test('after destroy(), delete() throws an error', () => {
+		const cache = new Cache<number, string>();
+
+		cache.set(1, 'value');
+		cache.destroy();
+
+		expect(() => cache.delete(1)).toThrow('Cache instance has been destroyed');
+	});
+
+	test('after destroy(), mdelete() throws an error', () => {
+		const cache = new Cache<number, string>();
+
+		cache.set(1, 'value');
+		cache.destroy();
+
+		expect(() => cache.mdelete([1])).toThrow('Cache instance has been destroyed');
+	});
+
+	test('after destroy(), forEach() throws an error', () => {
+		const cache = new Cache<number, string>();
+
+		cache.set(1, 'value');
+		cache.destroy();
+
+		expect(() => cache.forEach(() => {})).toThrow('Cache instance has been destroyed');
+	});
+
+	test('after destroy(), flush() does not throw', () => {
+		const cache = new Cache<number, string>();
+
+		cache.destroy();
+
+		expect(() => cache.flush()).not.toThrow();
+		expect(() => cache.flush(true)).not.toThrow();
+	});
+
+	// --- Timer cleanup verification ---
+
+	test('destroy() clears the timeout handle to undefined/null', () => {
+		const cache = new Cache<number, string>();
+
+		cache.set(1, 'value', 500);
+		expect((cache as any).timeoutHandle).not.toBeNull();
+
+		cache.destroy();
+		expect((cache as any).timeoutHandle).toBeNull();
+	});
+
+	test('multiple Cache instances — destroy all cleans up all timeouts', () => {
+		const caches = [new Cache<number, string>(), new Cache<number, string>(), new Cache<number, string>()];
+
+		caches.forEach((cache, i) => cache.set(i, `value-${i}`, 1000));
+
+		// All should have scheduled timeouts
+		caches.forEach((cache) => {
+			expect((cache as any).timeoutHandle).not.toBeNull();
+		});
+
+		caches.forEach((cache) => cache.destroy());
+
+		// All timeouts should be cleared
+		caches.forEach((cache) => {
+			expect((cache as any).timeoutHandle).toBeNull();
+			expect((cache as any).destroyed).toBe(true);
+		});
+	});
+
+	test('destroy() after some items expire via fake timers — timeout is stopped', () => {
+		const cache = new Cache<number, string>();
+		const callback = jest.fn();
+
+		cache.set(1, 'first', 100, callback);
+		cache.set(2, 'second', 500, callback);
+
+		// Advance past first item's TTL
+		jest.advanceTimersByTime(200);
+
+		// Trigger lazy expiration for first item
+		expect(cache.get(1)).toBeUndefined();
+
+		// Second item should still have a scheduled timeout
+		expect((cache as any).timeoutHandle).not.toBeNull();
+
+		cache.destroy();
+
+		expect((cache as any).timeoutHandle).toBeNull();
+
+		// Advance past second item's TTL — no more timer activity
+		jest.advanceTimersByTime(500);
+	});
+
+	test('flush() does NOT stop the cache from being functional', () => {
+		const cache = new Cache<number, string>();
+
+		cache.set(1, 'before-flush', 1000);
+		cache.flush();
+
+		// Cache should still be usable after flush
+		cache.set(2, 'after-flush');
+		expect(cache.get(2)).toBe('after-flush');
+		expect(cache.size).toBe(1);
+	});
+
+	test('flush() does NOT mark cache as destroyed', () => {
+		const cache = new Cache<number, string>();
+
+		cache.set(1, 'value');
+		cache.flush();
+
+		expect((cache as any).destroyed).toBe(false);
+
+		// set() should still work
+		expect(() => cache.set(2, 'new-value')).not.toThrow();
+	});
+
+	// --- Expiration callback interaction ---
+
+	test('destroy(true) invokes callbacks for items with expiration callbacks', () => {
+		const callback1 = jest.fn();
+		const callback2 = jest.fn();
+		const cache = new Cache<number, string>();
+
+		cache.set(1, 'val1', 1000, callback1);
+		cache.set(2, 'val2', undefined); // no callback
+		cache.set(3, 'val3', 2000, callback2);
+
+		cache.destroy(true);
+
+		expect(callback1).toHaveBeenCalledWith('val1');
+		expect(callback2).toHaveBeenCalledWith('val3');
+	});
+
+	// --- Edge cases ---
+
+	test('destroy() called immediately after construction (no items)', () => {
+		const cache = new Cache<number, string>();
+
+		expect(() => cache.destroy()).not.toThrow();
+		expect(() => cache.size).toThrow('Cache instance has been destroyed');
+	});
+
+	test('destroy() called from within an expiration callback', () => {
+		const cache = new Cache<number, string>();
+
+		cache.set(1, 'self-destruct', 100, () => {
+			// Calling destroy from within a callback during destroy(true)/flush(true)
+			// should be safe since destroy is idempotent
+			expect(() => cache.destroy()).not.toThrow();
+		});
+
+		cache.set(2, 'other', 200);
+
+		// Trigger via destroy(true) which calls flush(true)
+		cache.destroy(true);
+
+		expect((cache as any).destroyed).toBe(true);
+		expect((cache as any).cache.size).toBe(0);
+	});
+
+	test('destroy() during cleanup — items expiring while destroy is called', () => {
+		const cache = new Cache<number, string>();
+		const callback = jest.fn();
+
+		cache.set(1, 'value1', 100, callback);
+		cache.set(2, 'value2', 100, callback);
+
+		cache.destroy(true);
+
+		// Both callbacks should have been called exactly once
+		expect(callback).toHaveBeenCalledTimes(2);
+		expect((cache as any).timeoutHandle).toBeNull();
+	});
+
+	// --- Regression tests ---
+
+	describe('regression - existing functionality unchanged', () => {
+		test('set and get work before destroy', () => {
+			const cache = new Cache<number, string>();
+
+			cache.set(1, 'hello');
+			expect(cache.get(1)).toBe('hello');
+
+			cache.destroy();
+		});
+
+		test('take works before destroy', () => {
+			const cache = new Cache<number, string>();
+
+			cache.set(1, 'take-me');
+			expect(cache.take(1)).toBe('take-me');
+			expect(cache.take(1)).toBeUndefined();
+
+			cache.destroy();
+		});
+
+		test('has works before destroy', () => {
+			const cache = new Cache<number, string>();
+
+			cache.set(1, 'exists');
+			expect(cache.has(1)).toBe(true);
+			expect(cache.has(2)).toBe(false);
+
+			cache.destroy();
+		});
+
+		test('delete works before destroy', () => {
+			const cache = new Cache<number, string>();
+
+			cache.set(1, 'delete-me');
+			expect(cache.delete(1)).toBe(true);
+			expect(cache.delete(1)).toBe(false);
+
+			cache.destroy();
+		});
+
+		test('mdelete works before destroy', () => {
+			const cache = new Cache<number, string>();
+
+			cache.set(1, 'a');
+			cache.set(2, 'b');
+			cache.set(3, 'c');
+
+			cache.mdelete([1, 3]);
+
+			expect(cache.has(1)).toBe(false);
+			expect(cache.has(2)).toBe(true);
+			expect(cache.has(3)).toBe(false);
+
+			cache.destroy();
+		});
+
+		test('flush works before destroy', () => {
+			const callback = jest.fn();
+			const cache = new Cache<number, string>();
+
+			cache.set(1, 'val', undefined, callback);
+			cache.flush(true);
+
+			expect(callback).toHaveBeenCalledWith('val');
+			expect(cache.size).toBe(0);
+
+			// Cache is still functional after flush
+			cache.set(2, 'new');
+			expect(cache.get(2)).toBe('new');
+
+			cache.destroy();
+		});
+
+		test('forEach works before destroy', () => {
+			const cache = new Cache<number, string>();
+			const collected: [number, string][] = [];
+
+			cache.set(1, 'a');
+			cache.set(2, 'b');
+
+			cache.forEach((value, key) => collected.push([key, value]));
+
+			expect(collected).toEqual([
+				[1, 'a'],
+				[2, 'b'],
+			]);
+
+			cache.destroy();
+		});
+
+		test('size works before destroy', () => {
+			const cache = new Cache<number, string>();
+
+			expect(cache.size).toBe(0);
+			cache.set(1, 'a');
+			expect(cache.size).toBe(1);
+
+			cache.destroy();
+		});
+
+		test('TTL expiration still works before destroy', () => {
+			const cache = new Cache<number, string>();
+			const callback = jest.fn();
+
+			cache.set(1, 'expire-me', 100, callback);
+
+			jest.advanceTimersByTime(150);
+
+			expect(cache.get(1)).toBeUndefined();
+			expect(callback).toHaveBeenCalledWith('expire-me');
+
+			cache.destroy();
+		});
+
+		test('chained set still works', () => {
+			const cache = new Cache<number, string>();
+
+			cache.set(1, 'a').set(2, 'b').set(3, 'c');
+
+			expect(cache.size).toBe(3);
+
+			cache.destroy();
+		});
+	});
+});


### PR DESCRIPTION
## Problem

The Cache class provides no way to stop its internal cleanup timer, causing resource leaks in environments where Cache instances are created and discarded (e.g. test suites, short-lived services, HMR).

In Jest, orphaned timers keep the event loop alive, causing workers to fail to exit gracefully with:
```
A worker process has failed to exit gracefully and has been force exited.
```

## Solution

Add a `destroy()` method that:
- Clears the cleanup timer (`clearTimeout`)
- Flushes all cached entries
- Is idempotent (safe to call multiple times)
- Optionally invokes expiration callbacks via `destroy(true)`

After `destroy()`, all public methods (`set`, `get`, `has`, `take`, `delete`, `mdelete`, `size`, `forEach`) throw `'Cache instance has been destroyed'` to surface lifecycle bugs early (fail-fast pattern).

## Changes

- **`src/classes/Cache.ts`** — Add `destroyed` flag, `destroy()` method, and guards on all public methods
- **`test/Cache.destroy.test.ts`** — 31 tests covering lifecycle, use-after-destroy, timer cleanup, callback interaction, edge cases, and regressions
- **`README.md`** — API documentation for `destroy()` with Jest usage example
- **`package.json`** — Version bump 1.2.0 → 1.2.1

## Non-breaking

Existing code that never calls `destroy()` continues to work identically. The `.unref()` on timers is preserved so normal Node.js processes can still exit without explicitly calling `destroy()`.